### PR TITLE
feat: add GitHub Actions workflow to auto-label NSoC'26 issues

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,12 +4,15 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
       - name: Add NSoC'26 and enhancement labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,27 @@
+name: Auto Label NSoC'26
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add NSoC'26 and enhancement labels
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const now = new Date();
+            const start = new Date('2026-04-15');
+            const end = new Date('2026-08-31');
+            
+            if (now >= start && now <= end) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ["NSoC'26", "enhancement"]
+              });
+            }


### PR DESCRIPTION
Closes #12

## Changes
- Created `.github/workflows/auto-label.yml`
- Workflow triggers on `issues: opened` event
- Automatically adds `NSoC'26` and `enhancement` labels
- Added `permissions: issues: write` for label access
- Date condition ensures labels only apply during NSoC period (April 15 - August 31, 2026)

## Testing
- Tested on fork by creating test issues
- Labels `NSoC'26` and `enhancement` applied automatically ✅
- GitHub Actions workflow ran successfully ✅